### PR TITLE
Fix communication protocol

### DIFF
--- a/src/kx/c.java
+++ b/src/kx/c.java
@@ -101,7 +101,7 @@ public class c {
         io(s);
         java.io.ByteArrayOutputStream baos = new ByteArrayOutputStream();
         java.io.DataOutputStream dos = new DataOutputStream(baos);
-        dos.write((up + (retry ? "\3" : "")).getBytes());
+        dos.write((up + "\3").getBytes());
         dos.writeByte(0);
         dos.flush();
         outputStream.write(baos.toByteArray());


### PR DESCRIPTION
\3 has nothing to do with retry. It defines IPC protocol version that client supports.
See https://github.com/KxSystems/javakdb/blob/master/javakdb/src/main/java/com/kx/c.java#L257

It looks like we didn;t pass it before and kdb was falling back to pre-3 version which didn't support timestamps