### PR TITLE
do not retry on auth failure

### DIFF
--- a/src/kx/c.java
+++ b/src/kx/c.java
@@ -638,7 +638,9 @@ public class c {
     public synchronized K.KBase k(K.KBase x, ProgressCallback progress) throws K4Exception, IOException {
         try {
 
-            if (isClosed()) connect(true);
+            if (isClosed()) {
+                connect(false);
+            }
             try {
                 w(1, x);
                 inputStream.readFully(b = new byte[8]);


### PR DESCRIPTION
Retry on auth failure has couple of issues:
1. retry will always fails with the same auth error
2. unnecessary noise in audit logs